### PR TITLE
Build Docker Development Environment for LiveKit SFU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ coverage/
 docs/_build/
 docs/html/
 docs/latex/
+
+# Docker environment secrets
+docker/**/.env

--- a/README.md
+++ b/README.md
@@ -98,6 +98,86 @@ graph LR
 
 ---
 
+## 🐳 Development Environment (Docker)
+
+For easy local testing with LiveKit SFU, you can use the included Docker environment:
+
+### Quick Start
+
+**1. Navigate to the docker directory:**
+```bash
+cd docker/livekit
+```
+
+**2. Copy the example environment file:**
+```bash
+cp .env.example .env
+```
+
+**3. Generate API credentials:**
+```bash
+# Generate API Key
+openssl rand -base64 32
+
+# Generate API Secret
+openssl rand -base64 32
+```
+
+**4. Edit `.env` and set your credentials:**
+```env
+LIVEKIT_API_KEY=your-generated-api-key
+LIVEKIT_API_SECRET=your-generated-api-secret
+```
+
+**5. Start LiveKit:**
+```bash
+docker-compose up -d
+```
+
+### LiveKit Endpoints
+
+Once running, LiveKit will be available at:
+- **WebRTC API**: `http://localhost:7880`
+- **WHIP Endpoint**: `http://localhost:7880/whip`
+- **WHEP Endpoint**: `http://localhost:7880/whep`
+
+### Generating Access Tokens
+
+To connect to LiveKit, you need to generate access tokens. You can use the [LiveKit CLI](https://github.com/livekit/livekit-cli) or generate tokens programmatically.
+
+**Using LiveKit CLI:**
+```bash
+# Install LiveKit CLI
+go install github.com/livekit/livekit-cli/cmd/livekit-cli@latest
+
+# Generate a publisher token (for WHIP)
+livekit-cli create-token \
+  --api-key <LIVEKIT_API_KEY> \
+  --api-secret <LIVEKIT_API_SECRET> \
+  --join --room my-room --identity publisher \
+  --valid-for 24h
+
+# Generate a subscriber token (for WHEP)
+livekit-cli create-token \
+  --api-key <LIVEKIT_API_KEY> \
+  --api-secret <LIVEKIT_API_SECRET> \
+  --join --room my-room --identity subscriber \
+  --valid-for 24h
+```
+
+### Stopping LiveKit
+
+```bash
+docker-compose down
+```
+
+To remove all data:
+```bash
+docker-compose down -v
+```
+
+---
+
 ## 🛠️ Build from Source
 
 ### Dependencies
@@ -203,3 +283,83 @@ OBS同士のリレーはもちろん、ブラウザ・スマホ・他の配信�
 - OBSリレー：自宅↔スタジオ間の伝送
 - ゲスト参加：ブラウザ経由で映像を送信
 - スマホカメラ：WebRTCを使ったワイヤレスカメラ化
+
+---
+
+## 🐳 開発環境（Docker）
+
+ローカルでのテストを簡単に行うため、LiveKit SFUのDocker環境を用意しています。
+
+### クイックスタート
+
+**1. dockerディレクトリに移動:**
+```bash
+cd docker/livekit
+```
+
+**2. 環境変数ファイルをコピー:**
+```bash
+cp .env.example .env
+```
+
+**3. API認証情報を生成:**
+```bash
+# API Keyを生成
+openssl rand -base64 32
+
+# API Secretを生成
+openssl rand -base64 32
+```
+
+**4. `.env` ファイルを編集して認証情報を設定:**
+```env
+LIVEKIT_API_KEY=生成したAPIキー
+LIVEKIT_API_SECRET=生成したAPIシークレット
+```
+
+**5. LiveKitを起動:**
+```bash
+docker-compose up -d
+```
+
+### LiveKitエンドポイント
+
+起動後、以下のエンドポイントが利用可能になります：
+- **WebRTC API**: `http://localhost:7880`
+- **WHIP エンドポイント**: `http://localhost:7880/whip`
+- **WHEP エンドポイント**: `http://localhost:7880/whep`
+
+### アクセストークンの生成
+
+LiveKitに接続するには、アクセストークンが必要です。[LiveKit CLI](https://github.com/livekit/livekit-cli)を使用するか、プログラムで生成できます。
+
+**LiveKit CLIを使用:**
+```bash
+# LiveKit CLIをインストール
+go install github.com/livekit/livekit-cli/cmd/livekit-cli@latest
+
+# パブリッシャートークンを生成（WHIP用）
+livekit-cli create-token \
+  --api-key <LIVEKIT_API_KEY> \
+  --api-secret <LIVEKIT_API_SECRET> \
+  --join --room my-room --identity publisher \
+  --valid-for 24h
+
+# サブスクライバートークンを生成（WHEP用）
+livekit-cli create-token \
+  --api-key <LIVEKIT_API_KEY> \
+  --api-secret <LIVEKIT_API_SECRET> \
+  --join --room my-room --identity subscriber \
+  --valid-for 24h
+```
+
+### LiveKitを停止
+
+```bash
+docker-compose down
+```
+
+すべてのデータを削除する場合：
+```bash
+docker-compose down -v
+```

--- a/docker/livekit/.env.example
+++ b/docker/livekit/.env.example
@@ -1,0 +1,17 @@
+# LiveKit API Configuration
+# Copy this file to .env and fill in your values
+
+# API Key - Used for authentication with LiveKit server
+# Must match the key in livekit.yaml
+LIVEKIT_API_KEY=devkey
+
+# API Secret - Used for signing tokens
+# Must match the secret in livekit.yaml
+# WARNING: This is a default development secret. Use openssl rand -base64 32 to generate a secure secret!
+LIVEKIT_API_SECRET=devSecretKeyThatIsAtLeast32CharactersLongForSecurityPurposes
+
+# Optional: Custom domain for external access
+# LIVEKIT_DOMAIN=localhost
+
+# Optional: Enable debug logging
+# LIVEKIT_LOG_LEVEL=debug

--- a/docker/livekit/docker-compose.yml
+++ b/docker/livekit/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  livekit:
+    image: livekit/livekit-server:latest
+    container_name: livekit-server
+    ports:
+      # HTTP API and WHIP/WHEP endpoints
+      - "7880:7880"
+      # WebRTC UDP port range (for media streams)
+      - "50000-50200:50000-50200/udp"
+    volumes:
+      - ./livekit.yaml:/livekit.yaml
+    env_file:
+      - .env
+    command: --config /livekit.yaml --node-ip 127.0.0.1 --bind 0.0.0.0
+    networks:
+      - livekit-network
+    restart: unless-stopped
+
+networks:
+  livekit-network:
+    driver: bridge

--- a/docker/livekit/livekit.yaml
+++ b/docker/livekit/livekit.yaml
@@ -1,0 +1,22 @@
+port: 7880
+
+rtc:
+  # UDP port range for WebRTC media
+  port_range_start: 50000
+  port_range_end: 60000
+  # Use localhost for local development
+  use_external_ip: false
+
+# API keys for authentication
+# WARNING: These are default development keys. Replace with secure keys in production!
+keys:
+  devkey: devSecretKeyThatIsAtLeast32CharactersLongForSecurityPurposes
+
+# Room configuration
+room:
+  # Automatically create rooms if they don't exist
+  auto_create: true
+
+# Logging configuration
+logging:
+  level: info


### PR DESCRIPTION
## Summary
- Implement Docker environment for easily running LiveKit SFU locally
- Add comprehensive documentation in both English and Japanese
- Provide sensible default configuration for development

## Implementation Details

This PR implements Issue #5 by adding:

**Docker Configuration:**
- `docker/livekit/docker-compose.yml`: Container orchestration for LiveKit server
- `docker/livekit/livekit.yaml`: Server configuration with WebRTC settings
- `docker/livekit/.env.example`: Template for API credentials

**Documentation:**
- Updated [README.md](README.md) with Docker setup instructions (English & Japanese)
- Added usage guide for WHIP/WHEP endpoints
- Documented token generation using LiveKit CLI

**Features:**
- WHIP/WHEP endpoints accessible at `http://localhost:7880`
- UDP port range 50000-50200 configured for WebRTC media
- One-command startup: `docker-compose up -d`
- Default development credentials (devkey/devSecret)
- Automatic exclusion of `.env` files from version control

**Endpoints:**
- HTTP API: `http://localhost:7880`
- WHIP (Ingress): `http://localhost:7880/whip`
- WHEP (Egress): `http://localhost:7880/whep`

## Test Plan

Verified functionality:
- [x] `docker-compose up -d` successfully starts LiveKit server
- [x] HTTP endpoint responds with 200 OK at `http://localhost:7880`
- [x] Server starts without errors in logs
- [x] Configuration validates API key length requirements
- [x] `.env` file is properly excluded from git

## Related Issues

Closes #5

Generated with [Claude Code](https://claude.com/claude-code)