### PR TITLE
Fix Linux peer_connection_test race condition with shared vectors

### DIFF
--- a/tests/unit/peer_connection_test.cpp
+++ b/tests/unit/peer_connection_test.cpp
@@ -690,21 +690,22 @@ TEST_F(PeerConnectionTest, OfferCreationPerformance) {
 
 // Test: Multiple offer-answer exchanges
 TEST_F(PeerConnectionTest, MultipleOfferAnswerExchanges) {
-    auto config1 = createTestConfig();
+    CallbackState state;
+    auto config1 = createTestConfigWithState(state);
     auto pc1 = std::make_unique<PeerConnection>(config1);
 
     // First offer
     pc1->createOffer();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    ASSERT_FALSE(localDescriptions.empty());
-    std::string offer1 = localDescriptions[0].second;
-    localDescriptions.clear();
+    ASSERT_FALSE(state.localDescriptions.empty());
+    std::string offer1 = state.localDescriptions[0].second;
+    state.localDescriptions.clear();
 
     // Second offer
     pc1->createOffer();
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    ASSERT_FALSE(localDescriptions.empty());
-    std::string offer2 = localDescriptions[0].second;
+    ASSERT_FALSE(state.localDescriptions.empty());
+    std::string offer2 = state.localDescriptions[0].second;
 
     // Both offers should be valid
     EXPECT_FALSE(offer1.empty());


### PR DESCRIPTION
# Pull Request

## Summary

Fixes a critical race condition in peer_connection_test causing malloc corruption and crashes on Linux CI.

## Type

- [ ] Feature (新機能)
- [x] Bug Fix (バグ修正)
- [ ] Refactoring (リファクタリング)
- [ ] Documentation (ドキュメント)
- [ ] Testing (テスト追加・修正)
- [ ] Setup/Config (セットアップ・設定)
- [ ] Chore (その他の変更)

## Changes

### Root Cause

Multiple tests shared vectors (`logMessages`, `stateChanges`, `iceCandidates`, `localDescriptions`) via test fixture members. WebRTC callbacks execute on separate threads, causing concurrent unsynchronized writes to these shared vectors.

**Error on Linux CI:**
```
malloc_consolidate(): unaligned fastbin chunk detected
Aborted (core dumped)
```

Crash occurred between `LoggingCallbackIsInvoked` and `EmptyIceServersConfiguration` tests due to lingering callback threads from previous tests corrupting shared memory.

### Solution

**1. Modified `createTestConfig()` to use no-op callbacks:**
```cpp
config.logCallback = [](LogLevel level, const std::string& message) {
    // No-op: safe from race conditions
};
```

All shared vector writes removed from default config, eliminating race conditions.

**2. Updated tests requiring callback inspection:**

Tests that need to check callback data now use `createTestConfigWithState()` with independent `CallbackState` instances:
- `CreateOfferGeneratesLocalDescription`
- `IceCandidatesAreCollected`
- `StateChangesAreReported`
- `StateChangeCallbackReceivesAllTransitions`
- `LoggingCallbackIsInvoked`
- `OfferCreationPerformance`

### Why Linux-Specific?

Linux's glibc malloc has stricter corruption detection than macOS/Windows allocators. The race condition existed on all platforms, but only Linux CI detected it.

## Test Plan

- [x] Manual testing completed (local review)
- [ ] Unit tests added/updated (fix for existing tests)
- [ ] Integration tests added/updated
- [ ] Tested on Windows (pending CI)
- [ ] Tested on macOS (pending CI)
- [ ] Tested on Linux (pending CI)

### Test Steps

1. Run `peer_connection_test` multiple times
2. Verify no crashes or memory corruption
3. Confirm all tests pass on Linux CI
4. Verify no regressions on Windows/macOS

### Expected Behavior

- All tests pass without crashes
- No malloc corruption errors
- Clean teardown without lingering callbacks

### Actual Behavior

Will be confirmed by CI results.

## Related Issues

Fixes Linux CI failures introduced in recent commits. No specific issue number.

## Screenshots/Demo

N/A - This is a test infrastructure fix.

## Checklist

- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [ ] Documentation updated (not needed - test fix only)
- [x] No new warnings introduced
- [ ] Tests pass locally (awaiting CI confirmation)
- [x] Build succeeds locally

## Additional Notes

### Thread Safety Pattern

This fix establishes a pattern for thread-safe testing:
- **Default config**: Use no-op callbacks (safe but not inspectable)
- **Tests needing inspection**: Use `CallbackState` with `createTestConfigWithState()`
- **Isolation**: Each test has independent state, no sharing

### Previously Successful Pattern

The `createTestConfigWithState()` pattern was already used for:
- Tests with multiple `PeerConnection` instances
- Tests requiring concurrent execution

This PR extends that pattern to all tests that inspect callback data.

## Breaking Changes

- None

## Dependencies

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)