### PR TITLE
Implement media track reception for SFU (WHEP) mode

### DIFF
--- a/src/core/whep-client.hpp
+++ b/src/core/whep-client.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include "peer-connection.hpp"
+
 #include <functional>
 #include <map>
 #include <memory>
@@ -44,6 +46,13 @@ struct WHEPConfig {
     WHEPDisconnectedCallback onDisconnected;
     WHEPErrorCallback onError;
     WHEPIceCandidateCallback onIceCandidate;
+
+    // Media frame callbacks (optional - for receiving media tracks)
+    VideoFrameCallback videoFrameCallback;
+    AudioFrameCallback audioFrameCallback;
+
+    // ICE server configuration (optional - for WebRTC connection)
+    std::vector<std::string> iceServers;
 };
 
 /**
@@ -120,6 +129,26 @@ public:
      * @return true if connected
      */
     bool isConnected() const;
+
+    /**
+     * @brief Check if internal PeerConnection is created
+     * @return true if PeerConnection exists (frame callbacks are set)
+     */
+    bool hasPeerConnection() const;
+
+    /**
+     * @brief Connect to WHEP server and establish WebRTC connection
+     *
+     * This initiates the full WHEP connection flow:
+     * 1. Create internal PeerConnection (if frame callbacks are set)
+     * 2. Generate SDP offer
+     * 3. Send offer to WHEP server
+     * 4. Receive and apply SDP answer
+     * 5. Exchange ICE candidates
+     *
+     * @throws std::runtime_error if connection fails
+     */
+    void connect();
 
 private:
     class Impl;


### PR DESCRIPTION
# Pull Request

## Summary
Implement media track reception for SFU (WHEP) mode by adding VideoFrameCallback and AudioFrameCallback support to WHEPClient and wiring them in WebRTCSource.

## Type
- [x] Feature (新機能)
- [ ] Bug Fix (バグ修正)
- [ ] Refactoring (リファクタリング)
- [ ] Documentation (ドキュメント)
- [x] Testing (テスト追加・修正)
- [ ] Setup/Config (セットアップ・設定)
- [ ] Chore (その他の変更)

## Changes
- Add VideoFrameCallback and AudioFrameCallback to WHEPConfig struct
- Add iceServers configuration to WHEPConfig for WebRTC ICE negotiation
- Add internal PeerConnection to WHEPClient for media handling
- Add hasPeerConnection() and connect() methods to WHEPClient
- Wire frame callbacks from WebRTCSourceConfig to WHEPConfig in startWHEPMode()
- Add 5 new unit tests for WHEP media track handling:
  - ConfigWithFrameCallbacks
  - ConfigWithoutFrameCallbacksBackwardsCompatible
  - CreatesPeerConnectionWithFrameCallbacks
  - NoPeerConnectionWithoutFrameCallbacks
  - ConnectInitiatesWebRTCConnection

## Test Plan
- [x] Manual testing completed
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Tested on Windows
- [ ] Tested with OBS Studio

### Test Steps
1. Build with `cmake --build build --config Release`
2. Run all tests with `ctest --output-on-failure --verbose -C Release`
3. Verify all 211 tests pass

### Expected Behavior
- WHEPClient creates internal PeerConnection when frame callbacks are configured
- WHEPClient works in HTTP-only mode when no frame callbacks are set (backwards compatible)
- Media frames are delivered through the configured callbacks

### Actual Behavior
All tests pass. The implementation correctly:
- Creates PeerConnection only when frame callbacks are set
- Maintains backwards compatibility for HTTP-only WHEP usage
- Wires callbacks correctly between WebRTCSource and WHEPClient

## Related Issues
Closes #114

## Screenshots/Demo
N/A - Internal implementation change

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Build succeeds locally

## Additional Notes
The implementation uses the same pattern as P2P mode for frame callback handling, ensuring consistency across connection modes.

## Breaking Changes
- None (backwards compatible - frame callbacks are optional)

## Dependencies
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)