### PR TITLE
Add network statistics collection and display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ set(CORE_SOURCES
     src/core/p2p-connection.cpp
     src/core/reconnection-manager.cpp
     src/core/audio-only-config.cpp
+    src/core/network-statistics.cpp
 )
 
 add_library(obs-webrtc-core STATIC ${CORE_SOURCES})

--- a/src/core/network-statistics.cpp
+++ b/src/core/network-statistics.cpp
@@ -1,0 +1,319 @@
+/**
+ * @file network-statistics.cpp
+ * @brief Network statistics collection and formatting implementation
+ */
+
+#include "network-statistics.hpp"
+
+#include <cstdio>
+#include <iomanip>
+#include <sstream>
+
+namespace obswebrtc {
+namespace core {
+
+// =============================================================================
+// NetworkStatisticsCollector Implementation
+// =============================================================================
+
+class NetworkStatisticsCollector::Impl {
+public:
+    Impl()
+        : lastBitrateCalculation_(std::chrono::steady_clock::now()),
+          lastFrameRateCalculation_(std::chrono::steady_clock::now()),
+          lastBytesSent_(0),
+          lastBytesReceived_(0),
+          lastFramesReceived_(0) {}
+
+    NetworkStats getCurrentStats() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        NetworkStats stats = stats_;
+
+        // Calculate packet loss rate
+        uint64_t totalPackets = stats_.packetsReceived + stats_.packetsLost;
+        if (totalPackets > 0) {
+            stats.packetLossRate = (static_cast<double>(stats_.packetsLost) / totalPackets) * 100.0;
+        }
+
+        return stats;
+    }
+
+    void recordBytesSent(uint64_t bytes) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stats_.bytesSent += bytes;
+    }
+
+    void recordBytesReceived(uint64_t bytes) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stats_.bytesReceived += bytes;
+    }
+
+    void recordPacketSent() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stats_.packetsSent++;
+    }
+
+    void recordPacketReceived() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stats_.packetsReceived++;
+    }
+
+    void recordPacketLost() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stats_.packetsLost++;
+    }
+
+    void updateRTT(uint32_t rttMs) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stats_.rttMs = rttMs;
+    }
+
+    void updateJitter(double jitterMs) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stats_.jitterMs = jitterMs;
+    }
+
+    void recordFrameSent() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stats_.framesSent++;
+    }
+
+    void recordFrameReceived() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stats_.framesReceived++;
+    }
+
+    void recordFrameDropped() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stats_.framesDropped++;
+    }
+
+    void calculateBitrates() {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            now - lastBitrateCalculation_).count();
+
+        if (elapsed > 0) {
+            // Calculate send bitrate (bytes to kbps: bytes * 8 / 1000 / (elapsed_ms / 1000))
+            // Simplified: bytes * 8 / elapsed_ms
+            uint64_t bytesSentDelta = stats_.bytesSent - lastBytesSent_;
+            stats_.sendBitrateKbps = static_cast<uint32_t>((bytesSentDelta * 8) / elapsed);
+
+            // Calculate receive bitrate
+            uint64_t bytesReceivedDelta = stats_.bytesReceived - lastBytesReceived_;
+            stats_.receiveBitrateKbps = static_cast<uint32_t>((bytesReceivedDelta * 8) / elapsed);
+
+            // Update last values
+            lastBytesSent_ = stats_.bytesSent;
+            lastBytesReceived_ = stats_.bytesReceived;
+            lastBitrateCalculation_ = now;
+        }
+    }
+
+    void calculateFrameRate() {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        auto now = std::chrono::steady_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            now - lastFrameRateCalculation_).count();
+
+        if (elapsed > 0) {
+            uint64_t framesReceivedDelta = stats_.framesReceived - lastFramesReceived_;
+            stats_.frameRate = (static_cast<double>(framesReceivedDelta) * 1000.0) / elapsed;
+
+            lastFramesReceived_ = stats_.framesReceived;
+            lastFrameRateCalculation_ = now;
+        }
+    }
+
+    void reset() {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        stats_ = NetworkStats{};
+        lastBytesSent_ = 0;
+        lastBytesReceived_ = 0;
+        lastFramesReceived_ = 0;
+        lastBitrateCalculation_ = std::chrono::steady_clock::now();
+        lastFrameRateCalculation_ = std::chrono::steady_clock::now();
+    }
+
+    void setStatsCallback(StatsCallback callback) {
+        std::lock_guard<std::mutex> lock(callbackMutex_);
+        callback_ = std::move(callback);
+    }
+
+    void notifyStatsUpdate() {
+        StatsCallback callback;
+        NetworkStats stats;
+
+        {
+            std::lock_guard<std::mutex> lock(callbackMutex_);
+            callback = callback_;
+        }
+
+        if (callback) {
+            stats = getCurrentStats();
+            callback(stats);
+        }
+    }
+
+private:
+    NetworkStats stats_;
+    mutable std::mutex mutex_;
+
+    // For bitrate calculation
+    std::chrono::steady_clock::time_point lastBitrateCalculation_;
+    uint64_t lastBytesSent_;
+    uint64_t lastBytesReceived_;
+
+    // For frame rate calculation
+    std::chrono::steady_clock::time_point lastFrameRateCalculation_;
+    uint64_t lastFramesReceived_;
+
+    // Callback
+    StatsCallback callback_;
+    std::mutex callbackMutex_;
+};
+
+NetworkStatisticsCollector::NetworkStatisticsCollector()
+    : impl_(std::make_unique<Impl>()) {}
+
+NetworkStatisticsCollector::~NetworkStatisticsCollector() = default;
+
+NetworkStats NetworkStatisticsCollector::getCurrentStats() const {
+    return impl_->getCurrentStats();
+}
+
+void NetworkStatisticsCollector::recordBytesSent(uint64_t bytes) {
+    impl_->recordBytesSent(bytes);
+}
+
+void NetworkStatisticsCollector::recordBytesReceived(uint64_t bytes) {
+    impl_->recordBytesReceived(bytes);
+}
+
+void NetworkStatisticsCollector::recordPacketSent() {
+    impl_->recordPacketSent();
+}
+
+void NetworkStatisticsCollector::recordPacketReceived() {
+    impl_->recordPacketReceived();
+}
+
+void NetworkStatisticsCollector::recordPacketLost() {
+    impl_->recordPacketLost();
+}
+
+void NetworkStatisticsCollector::updateRTT(uint32_t rttMs) {
+    impl_->updateRTT(rttMs);
+}
+
+void NetworkStatisticsCollector::updateJitter(double jitterMs) {
+    impl_->updateJitter(jitterMs);
+}
+
+void NetworkStatisticsCollector::recordFrameSent() {
+    impl_->recordFrameSent();
+}
+
+void NetworkStatisticsCollector::recordFrameReceived() {
+    impl_->recordFrameReceived();
+}
+
+void NetworkStatisticsCollector::recordFrameDropped() {
+    impl_->recordFrameDropped();
+}
+
+void NetworkStatisticsCollector::calculateBitrates() {
+    impl_->calculateBitrates();
+}
+
+void NetworkStatisticsCollector::calculateFrameRate() {
+    impl_->calculateFrameRate();
+}
+
+void NetworkStatisticsCollector::reset() {
+    impl_->reset();
+}
+
+void NetworkStatisticsCollector::setStatsCallback(StatsCallback callback) {
+    impl_->setStatsCallback(std::move(callback));
+}
+
+void NetworkStatisticsCollector::notifyStatsUpdate() {
+    impl_->notifyStatsUpdate();
+}
+
+// =============================================================================
+// NetworkStatisticsFormatter Implementation
+// =============================================================================
+
+std::string NetworkStatisticsFormatter::formatStats(const NetworkStats& stats) {
+    std::ostringstream oss;
+
+    oss << "Network Statistics:\n";
+    oss << "  Send Bitrate: " << formatBitrate(stats.sendBitrateKbps) << "\n";
+    oss << "  Receive Bitrate: " << formatBitrate(stats.receiveBitrateKbps) << "\n";
+    oss << "  RTT: " << formatRTT(stats.rttMs) << "\n";
+    oss << "  Jitter: " << std::fixed << std::setprecision(2) << stats.jitterMs << " ms\n";
+    oss << "  Packet Loss: " << formatPacketLoss(stats.packetLossRate) << "\n";
+    oss << "  Bytes Sent: " << formatBytes(stats.bytesSent) << "\n";
+    oss << "  Bytes Received: " << formatBytes(stats.bytesReceived) << "\n";
+    oss << "  Packets Sent: " << stats.packetsSent << "\n";
+    oss << "  Packets Received: " << stats.packetsReceived << "\n";
+    oss << "  Packets Lost: " << stats.packetsLost << "\n";
+    oss << "  Frame Rate: " << std::fixed << std::setprecision(1) << stats.frameRate << " fps\n";
+    oss << "  Frames Dropped: " << stats.framesDropped << "\n";
+
+    return oss.str();
+}
+
+std::string NetworkStatisticsFormatter::formatBitrate(uint32_t bitrateKbps) {
+    std::ostringstream oss;
+
+    if (bitrateKbps >= 1000) {
+        oss << std::fixed << std::setprecision(1)
+            << (static_cast<double>(bitrateKbps) / 1000.0) << " Mbps";
+    } else {
+        oss << bitrateKbps << " kbps";
+    }
+
+    return oss.str();
+}
+
+std::string NetworkStatisticsFormatter::formatBytes(uint64_t bytes) {
+    std::ostringstream oss;
+
+    if (bytes >= 1000000000) {
+        oss << std::fixed << std::setprecision(1)
+            << (static_cast<double>(bytes) / 1000000000.0) << " GB";
+    } else if (bytes >= 1000000) {
+        oss << std::fixed << std::setprecision(1)
+            << (static_cast<double>(bytes) / 1000000.0) << " MB";
+    } else if (bytes >= 1000) {
+        oss << std::fixed << std::setprecision(1)
+            << (static_cast<double>(bytes) / 1000.0) << " KB";
+    } else {
+        oss << bytes << " B";
+    }
+
+    return oss.str();
+}
+
+std::string NetworkStatisticsFormatter::formatRTT(uint32_t rttMs) {
+    std::ostringstream oss;
+    oss << rttMs << " ms";
+    return oss.str();
+}
+
+std::string NetworkStatisticsFormatter::formatPacketLoss(double lossRate) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2) << lossRate << "%";
+    return oss.str();
+}
+
+}  // namespace core
+}  // namespace obswebrtc

--- a/src/core/network-statistics.hpp
+++ b/src/core/network-statistics.hpp
@@ -1,0 +1,219 @@
+/**
+ * @file network-statistics.hpp
+ * @brief Network statistics collection and formatting for WebRTC connections
+ *
+ * This module provides:
+ * - Real-time network statistics collection
+ * - Bitrate, packet loss, RTT, and jitter monitoring
+ * - Statistics formatting for display
+ * - Thread-safe statistics access
+ */
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace obswebrtc {
+namespace core {
+
+/**
+ * @brief Network statistics data structure
+ */
+struct NetworkStats {
+    // Byte counters
+    uint64_t bytesSent = 0;
+    uint64_t bytesReceived = 0;
+
+    // Packet counters
+    uint64_t packetsSent = 0;
+    uint64_t packetsReceived = 0;
+    uint64_t packetsLost = 0;
+    double packetLossRate = 0.0;  // Percentage (0-100)
+
+    // Latency metrics
+    uint32_t rttMs = 0;       // Round-trip time in milliseconds
+    double jitterMs = 0.0;    // Jitter in milliseconds
+
+    // Bitrate (calculated)
+    uint32_t sendBitrateKbps = 0;
+    uint32_t receiveBitrateKbps = 0;
+
+    // Frame statistics
+    uint64_t framesSent = 0;
+    uint64_t framesReceived = 0;
+    uint64_t framesDropped = 0;
+    double frameRate = 0.0;  // Frames per second
+};
+
+/**
+ * @brief Callback type for statistics updates
+ */
+using StatsCallback = std::function<void(const NetworkStats&)>;
+
+/**
+ * @brief Collects and manages network statistics
+ *
+ * This class provides thread-safe statistics collection for WebRTC connections.
+ * Statistics are updated incrementally and can be retrieved at any time.
+ */
+class NetworkStatisticsCollector {
+public:
+    /**
+     * @brief Construct a new Network Statistics Collector
+     */
+    NetworkStatisticsCollector();
+
+    /**
+     * @brief Destructor
+     */
+    ~NetworkStatisticsCollector();
+
+    // Delete copy constructor and assignment (non-copyable)
+    NetworkStatisticsCollector(const NetworkStatisticsCollector&) = delete;
+    NetworkStatisticsCollector& operator=(const NetworkStatisticsCollector&) = delete;
+
+    /**
+     * @brief Get current statistics snapshot
+     * @return Current network statistics
+     */
+    NetworkStats getCurrentStats() const;
+
+    /**
+     * @brief Record bytes sent
+     * @param bytes Number of bytes sent
+     */
+    void recordBytesSent(uint64_t bytes);
+
+    /**
+     * @brief Record bytes received
+     * @param bytes Number of bytes received
+     */
+    void recordBytesReceived(uint64_t bytes);
+
+    /**
+     * @brief Record a packet sent
+     */
+    void recordPacketSent();
+
+    /**
+     * @brief Record a packet received
+     */
+    void recordPacketReceived();
+
+    /**
+     * @brief Record a packet lost
+     */
+    void recordPacketLost();
+
+    /**
+     * @brief Update RTT measurement
+     * @param rttMs Round-trip time in milliseconds
+     */
+    void updateRTT(uint32_t rttMs);
+
+    /**
+     * @brief Update jitter measurement
+     * @param jitterMs Jitter in milliseconds
+     */
+    void updateJitter(double jitterMs);
+
+    /**
+     * @brief Record a frame sent
+     */
+    void recordFrameSent();
+
+    /**
+     * @brief Record a frame received
+     */
+    void recordFrameReceived();
+
+    /**
+     * @brief Record a frame dropped
+     */
+    void recordFrameDropped();
+
+    /**
+     * @brief Calculate current bitrates
+     *
+     * Call periodically to update bitrate calculations.
+     */
+    void calculateBitrates();
+
+    /**
+     * @brief Calculate current frame rate
+     *
+     * Call periodically to update frame rate calculation.
+     */
+    void calculateFrameRate();
+
+    /**
+     * @brief Reset all statistics to initial values
+     */
+    void reset();
+
+    /**
+     * @brief Set callback for statistics updates
+     * @param callback Function to call when statistics are updated
+     */
+    void setStatsCallback(StatsCallback callback);
+
+    /**
+     * @brief Notify that statistics have been updated
+     *
+     * This triggers the callback if one is set.
+     */
+    void notifyStatsUpdate();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+/**
+ * @brief Formats network statistics for display
+ */
+class NetworkStatisticsFormatter {
+public:
+    /**
+     * @brief Format complete statistics to string
+     * @param stats Statistics to format
+     * @return Formatted string
+     */
+    static std::string formatStats(const NetworkStats& stats);
+
+    /**
+     * @brief Format bitrate for display
+     * @param bitrateKbps Bitrate in kbps
+     * @return Formatted string (e.g., "2.5 Mbps")
+     */
+    static std::string formatBitrate(uint32_t bitrateKbps);
+
+    /**
+     * @brief Format bytes for display
+     * @param bytes Number of bytes
+     * @return Formatted string (e.g., "1.5 GB")
+     */
+    static std::string formatBytes(uint64_t bytes);
+
+    /**
+     * @brief Format RTT for display
+     * @param rttMs RTT in milliseconds
+     * @return Formatted string (e.g., "50 ms")
+     */
+    static std::string formatRTT(uint32_t rttMs);
+
+    /**
+     * @brief Format packet loss for display
+     * @param lossRate Packet loss rate as percentage
+     * @return Formatted string (e.g., "5.50%")
+     */
+    static std::string formatPacketLoss(double lossRate);
+};
+
+}  // namespace core
+}  // namespace obswebrtc

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -254,6 +254,29 @@ else()
     gtest_discover_tests(audio_only_mode_test)
 endif()
 
+# Network Statistics test executable
+add_executable(network_statistics_test
+    network_statistics_test.cpp
+)
+
+target_include_directories(network_statistics_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+)
+
+target_link_libraries(network_statistics_test PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+    obs-webrtc-core
+)
+
+# Discover Network Statistics tests
+if(WIN32)
+    gtest_add_tests(TARGET network_statistics_test)
+else()
+    gtest_discover_tests(network_statistics_test)
+endif()
+
 # Settings Dialog test executable (requires Qt)
 if(QT_FOUND)
     add_executable(settings_dialog_test

--- a/tests/unit/network_statistics_test.cpp
+++ b/tests/unit/network_statistics_test.cpp
@@ -1,0 +1,480 @@
+/**
+ * @file network_statistics_test.cpp
+ * @brief Unit tests for NetworkStatistics
+ */
+
+#include "core/network-statistics.hpp"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <thread>
+
+using namespace obswebrtc::core;
+using namespace testing;
+
+/**
+ * @brief Test fixture for NetworkStatistics tests
+ */
+class NetworkStatisticsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // No setup needed
+    }
+
+    void TearDown() override {
+        // No teardown needed
+    }
+};
+
+// =============================================================================
+// NetworkStats Structure Tests
+// =============================================================================
+
+/**
+ * @brief Test default values of NetworkStats
+ */
+TEST_F(NetworkStatisticsTest, NetworkStatsDefaultValues) {
+    NetworkStats stats;
+
+    EXPECT_EQ(stats.bytesSent, 0);
+    EXPECT_EQ(stats.bytesReceived, 0);
+    EXPECT_EQ(stats.packetsSent, 0);
+    EXPECT_EQ(stats.packetsReceived, 0);
+    EXPECT_EQ(stats.packetsLost, 0);
+    EXPECT_DOUBLE_EQ(stats.packetLossRate, 0.0);
+    EXPECT_EQ(stats.rttMs, 0);
+    EXPECT_DOUBLE_EQ(stats.jitterMs, 0.0);
+    EXPECT_EQ(stats.sendBitrateKbps, 0);
+    EXPECT_EQ(stats.receiveBitrateKbps, 0);
+    EXPECT_EQ(stats.framesSent, 0);
+    EXPECT_EQ(stats.framesReceived, 0);
+    EXPECT_EQ(stats.framesDropped, 0);
+    EXPECT_DOUBLE_EQ(stats.frameRate, 0.0);
+}
+
+// =============================================================================
+// NetworkStatisticsCollector Tests
+// =============================================================================
+
+/**
+ * @brief Test collector construction
+ */
+TEST_F(NetworkStatisticsTest, CollectorConstruction) {
+    EXPECT_NO_THROW({
+        NetworkStatisticsCollector collector;
+    });
+}
+
+/**
+ * @brief Test getting current stats
+ */
+TEST_F(NetworkStatisticsTest, GetCurrentStats) {
+    NetworkStatisticsCollector collector;
+    NetworkStats stats = collector.getCurrentStats();
+
+    // Initial stats should be all zeros
+    EXPECT_EQ(stats.bytesSent, 0);
+    EXPECT_EQ(stats.bytesReceived, 0);
+}
+
+/**
+ * @brief Test recording sent bytes
+ */
+TEST_F(NetworkStatisticsTest, RecordSentBytes) {
+    NetworkStatisticsCollector collector;
+
+    collector.recordBytesSent(1000);
+    collector.recordBytesSent(500);
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.bytesSent, 1500);
+}
+
+/**
+ * @brief Test recording received bytes
+ */
+TEST_F(NetworkStatisticsTest, RecordReceivedBytes) {
+    NetworkStatisticsCollector collector;
+
+    collector.recordBytesReceived(2000);
+    collector.recordBytesReceived(800);
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.bytesReceived, 2800);
+}
+
+/**
+ * @brief Test recording sent packets
+ */
+TEST_F(NetworkStatisticsTest, RecordSentPackets) {
+    NetworkStatisticsCollector collector;
+
+    collector.recordPacketSent();
+    collector.recordPacketSent();
+    collector.recordPacketSent();
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.packetsSent, 3);
+}
+
+/**
+ * @brief Test recording received packets
+ */
+TEST_F(NetworkStatisticsTest, RecordReceivedPackets) {
+    NetworkStatisticsCollector collector;
+
+    collector.recordPacketReceived();
+    collector.recordPacketReceived();
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.packetsReceived, 2);
+}
+
+/**
+ * @brief Test recording lost packets
+ */
+TEST_F(NetworkStatisticsTest, RecordLostPackets) {
+    NetworkStatisticsCollector collector;
+
+    collector.recordPacketLost();
+    collector.recordPacketLost();
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.packetsLost, 2);
+}
+
+/**
+ * @brief Test packet loss rate calculation
+ */
+TEST_F(NetworkStatisticsTest, PacketLossRateCalculation) {
+    NetworkStatisticsCollector collector;
+
+    // Receive 90 packets, lose 10
+    for (int i = 0; i < 90; i++) {
+        collector.recordPacketReceived();
+    }
+    for (int i = 0; i < 10; i++) {
+        collector.recordPacketLost();
+    }
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_NEAR(stats.packetLossRate, 10.0, 0.1);  // 10% loss
+}
+
+/**
+ * @brief Test packet loss rate with no packets
+ */
+TEST_F(NetworkStatisticsTest, PacketLossRateNoPackets) {
+    NetworkStatisticsCollector collector;
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_DOUBLE_EQ(stats.packetLossRate, 0.0);
+}
+
+/**
+ * @brief Test updating RTT
+ */
+TEST_F(NetworkStatisticsTest, UpdateRTT) {
+    NetworkStatisticsCollector collector;
+
+    collector.updateRTT(50);
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.rttMs, 50);
+
+    collector.updateRTT(30);
+    stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.rttMs, 30);
+}
+
+/**
+ * @brief Test updating jitter
+ */
+TEST_F(NetworkStatisticsTest, UpdateJitter) {
+    NetworkStatisticsCollector collector;
+
+    collector.updateJitter(5.5);
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_DOUBLE_EQ(stats.jitterMs, 5.5);
+
+    collector.updateJitter(3.2);
+    stats = collector.getCurrentStats();
+    EXPECT_DOUBLE_EQ(stats.jitterMs, 3.2);
+}
+
+/**
+ * @brief Test recording sent frames
+ */
+TEST_F(NetworkStatisticsTest, RecordSentFrames) {
+    NetworkStatisticsCollector collector;
+
+    collector.recordFrameSent();
+    collector.recordFrameSent();
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.framesSent, 2);
+}
+
+/**
+ * @brief Test recording received frames
+ */
+TEST_F(NetworkStatisticsTest, RecordReceivedFrames) {
+    NetworkStatisticsCollector collector;
+
+    collector.recordFrameReceived();
+    collector.recordFrameReceived();
+    collector.recordFrameReceived();
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.framesReceived, 3);
+}
+
+/**
+ * @brief Test recording dropped frames
+ */
+TEST_F(NetworkStatisticsTest, RecordDroppedFrames) {
+    NetworkStatisticsCollector collector;
+
+    collector.recordFrameDropped();
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.framesDropped, 1);
+}
+
+/**
+ * @brief Test resetting statistics
+ */
+TEST_F(NetworkStatisticsTest, ResetStatistics) {
+    NetworkStatisticsCollector collector;
+
+    collector.recordBytesSent(1000);
+    collector.recordBytesReceived(2000);
+    collector.recordPacketSent();
+    collector.recordPacketReceived();
+    collector.recordPacketLost();
+    collector.updateRTT(50);
+    collector.updateJitter(5.0);
+
+    collector.reset();
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.bytesSent, 0);
+    EXPECT_EQ(stats.bytesReceived, 0);
+    EXPECT_EQ(stats.packetsSent, 0);
+    EXPECT_EQ(stats.packetsReceived, 0);
+    EXPECT_EQ(stats.packetsLost, 0);
+    EXPECT_EQ(stats.rttMs, 0);
+    EXPECT_DOUBLE_EQ(stats.jitterMs, 0.0);
+}
+
+// =============================================================================
+// Statistics Callback Tests
+// =============================================================================
+
+/**
+ * @brief Test statistics callback invocation
+ */
+TEST_F(NetworkStatisticsTest, StatisticsCallbackIsInvoked) {
+    NetworkStatisticsCollector collector;
+    bool callbackInvoked = false;
+    NetworkStats receivedStats;
+
+    collector.setStatsCallback([&](const NetworkStats& stats) {
+        callbackInvoked = true;
+        receivedStats = stats;
+    });
+
+    collector.recordBytesSent(1000);
+    collector.notifyStatsUpdate();
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_EQ(receivedStats.bytesSent, 1000);
+}
+
+/**
+ * @brief Test clearing statistics callback
+ */
+TEST_F(NetworkStatisticsTest, ClearStatisticsCallback) {
+    NetworkStatisticsCollector collector;
+    int callbackCount = 0;
+
+    collector.setStatsCallback([&](const NetworkStats& stats) {
+        callbackCount++;
+    });
+
+    collector.notifyStatsUpdate();
+    EXPECT_EQ(callbackCount, 1);
+
+    collector.setStatsCallback(nullptr);
+    collector.notifyStatsUpdate();
+    EXPECT_EQ(callbackCount, 1);  // Should not increase
+}
+
+// =============================================================================
+// Bitrate Calculation Tests
+// =============================================================================
+
+/**
+ * @brief Test send bitrate calculation
+ */
+TEST_F(NetworkStatisticsTest, SendBitrateCalculation) {
+    NetworkStatisticsCollector collector;
+
+    // Record 125KB (1Mbps for 1 second)
+    collector.recordBytesSent(125000);
+
+    // Wait a bit and calculate bitrate
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    collector.calculateBitrates();
+    NetworkStats stats = collector.getCurrentStats();
+
+    // Bitrate should be approximately 1000 kbps (may vary due to timing)
+    // We use a wide range because timing is not precise in tests
+    EXPECT_GT(stats.sendBitrateKbps, 0);
+}
+
+/**
+ * @brief Test receive bitrate calculation
+ */
+TEST_F(NetworkStatisticsTest, ReceiveBitrateCalculation) {
+    NetworkStatisticsCollector collector;
+
+    // Record 250KB (2Mbps for 1 second)
+    collector.recordBytesReceived(250000);
+
+    // Wait a bit and calculate bitrate
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    collector.calculateBitrates();
+    NetworkStats stats = collector.getCurrentStats();
+
+    // Bitrate should be approximately 2000 kbps
+    EXPECT_GT(stats.receiveBitrateKbps, 0);
+}
+
+// =============================================================================
+// Frame Rate Calculation Tests
+// =============================================================================
+
+/**
+ * @brief Test frame rate calculation
+ */
+TEST_F(NetworkStatisticsTest, FrameRateCalculation) {
+    NetworkStatisticsCollector collector;
+
+    // Record 30 frames
+    for (int i = 0; i < 30; i++) {
+        collector.recordFrameReceived();
+    }
+
+    // Wait a bit and calculate frame rate
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    collector.calculateFrameRate();
+    NetworkStats stats = collector.getCurrentStats();
+
+    // Frame rate should be positive
+    EXPECT_GT(stats.frameRate, 0.0);
+}
+
+// =============================================================================
+// Thread Safety Tests
+// =============================================================================
+
+/**
+ * @brief Test concurrent access to statistics
+ */
+TEST_F(NetworkStatisticsTest, ConcurrentAccess) {
+    NetworkStatisticsCollector collector;
+    std::atomic<bool> running{true};
+    const int iterations = 100;
+
+    // Writer thread
+    std::thread writer([&]() {
+        for (int i = 0; i < iterations && running; i++) {
+            collector.recordBytesSent(100);
+            collector.recordBytesReceived(100);
+            collector.recordPacketSent();
+            collector.recordPacketReceived();
+        }
+    });
+
+    // Reader thread
+    std::thread reader([&]() {
+        for (int i = 0; i < iterations && running; i++) {
+            NetworkStats stats = collector.getCurrentStats();
+            // Just verify we can read without crash
+            (void)stats.bytesSent;
+        }
+    });
+
+    writer.join();
+    running = false;
+    reader.join();
+
+    NetworkStats stats = collector.getCurrentStats();
+    EXPECT_EQ(stats.bytesSent, iterations * 100);
+    EXPECT_EQ(stats.bytesReceived, iterations * 100);
+}
+
+// =============================================================================
+// NetworkStatisticsFormatter Tests
+// =============================================================================
+
+/**
+ * @brief Test formatting stats to string
+ */
+TEST_F(NetworkStatisticsTest, FormatStatsToString) {
+    NetworkStats stats;
+    stats.bytesSent = 1000000;
+    stats.bytesReceived = 2000000;
+    stats.sendBitrateKbps = 2500;
+    stats.receiveBitrateKbps = 5000;
+    stats.rttMs = 50;
+    stats.packetLossRate = 1.5;
+
+    std::string formatted = NetworkStatisticsFormatter::formatStats(stats);
+
+    EXPECT_FALSE(formatted.empty());
+    EXPECT_NE(formatted.find("2.5 Mbps"), std::string::npos);  // Send bitrate
+    EXPECT_NE(formatted.find("5.0 Mbps"), std::string::npos);  // Receive bitrate
+    EXPECT_NE(formatted.find("50 ms"), std::string::npos);     // RTT
+}
+
+/**
+ * @brief Test formatting bitrate
+ */
+TEST_F(NetworkStatisticsTest, FormatBitrate) {
+    EXPECT_EQ(NetworkStatisticsFormatter::formatBitrate(500), "500 kbps");
+    EXPECT_EQ(NetworkStatisticsFormatter::formatBitrate(1500), "1.5 Mbps");
+    EXPECT_EQ(NetworkStatisticsFormatter::formatBitrate(10000), "10.0 Mbps");
+}
+
+/**
+ * @brief Test formatting bytes
+ */
+TEST_F(NetworkStatisticsTest, FormatBytes) {
+    EXPECT_EQ(NetworkStatisticsFormatter::formatBytes(500), "500 B");
+    EXPECT_EQ(NetworkStatisticsFormatter::formatBytes(1500), "1.5 KB");
+    EXPECT_EQ(NetworkStatisticsFormatter::formatBytes(1500000), "1.5 MB");
+    EXPECT_EQ(NetworkStatisticsFormatter::formatBytes(1500000000), "1.5 GB");
+}
+
+/**
+ * @brief Test formatting RTT
+ */
+TEST_F(NetworkStatisticsTest, FormatRTT) {
+    EXPECT_EQ(NetworkStatisticsFormatter::formatRTT(50), "50 ms");
+    EXPECT_EQ(NetworkStatisticsFormatter::formatRTT(0), "0 ms");
+}
+
+/**
+ * @brief Test formatting packet loss
+ */
+TEST_F(NetworkStatisticsTest, FormatPacketLoss) {
+    EXPECT_EQ(NetworkStatisticsFormatter::formatPacketLoss(0.0), "0.00%");
+    EXPECT_EQ(NetworkStatisticsFormatter::formatPacketLoss(5.5), "5.50%");
+    EXPECT_EQ(NetworkStatisticsFormatter::formatPacketLoss(100.0), "100.00%");
+}


### PR DESCRIPTION
# Pull Request

## Summary
ネットワーク統計の収集・表示機能を追加

## Type
- [x] Feature (新機能)
- [ ] Bug Fix (バグ修正)
- [ ] Refactoring (リファクタリング)
- [ ] Documentation (ドキュメント)
- [ ] Testing (テスト追加・修正)
- [ ] Setup/Config (セットアップ・設定)
- [ ] Chore (その他の変更)

## Changes
- `NetworkStats` 構造体を追加（メトリクス格納用）
- `NetworkStatisticsCollector` クラスを実装（スレッドセーフなデータ収集）
- ビットレート（送信/受信）、RTT、ジッター、パケットロスの追跡をサポート
- フレームレートとドロップフレームのカウント機能を実装
- `NetworkStatisticsFormatter` を追加（人間が読める形式への変換）
- 27個の包括的なユニットテストを追加

### 収集する統計情報
- **バイトカウンター**: 送信/受信バイト数
- **パケットカウンター**: 送信/受信/ロストパケット数
- **レイテンシメトリクス**: RTT (ms)、ジッター (ms)
- **ビットレート**: 送信/受信 (kbps)
- **フレーム統計**: 送信/受信/ドロップフレーム数、フレームレート (fps)

## Test Plan
- [x] Manual testing completed
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Tested on Windows
- [ ] Tested with OBS Studio

### Test Steps
1. `cmake -B build -DBUILD_TESTS_ONLY=ON` でビルド設定
2. `cmake --build build --config Release --target network_statistics_test` でテストビルド
3. `./build/tests/unit/Release/network_statistics_test.exe` でテスト実行

### Expected Behavior
- 全27テストがパス
- 統計の収集・フォーマットが正しく動作

### Actual Behavior
期待通りに動作

## Related Issues
Closes #28

## Screenshots/Demo
N/A

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Build succeeds locally

## Additional Notes
このPRはネットワーク統計収集の基盤を実装しています。
PeerConnectionやWHIP/WHEPクライアントとの統合は後続のPRで実装予定です。

## Breaking Changes
- None

## Dependencies
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)