### PR TITLE
Add ConnectionManager for multi-stream support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ set(CORE_SOURCES
     src/core/audio-only-config.cpp
     src/core/network-statistics.cpp
     src/core/hardware-encoder.cpp
+    src/core/connection-manager.cpp
 )
 
 add_library(obs-webrtc-core STATIC ${CORE_SOURCES})

--- a/src/core/connection-manager.cpp
+++ b/src/core/connection-manager.cpp
@@ -1,0 +1,254 @@
+/**
+ * @file connection-manager.cpp
+ * @brief Multi-connection management implementation
+ */
+
+#include "connection-manager.hpp"
+
+#include <chrono>
+#include <map>
+#include <mutex>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+
+namespace obswebrtc {
+namespace core {
+
+// =============================================================================
+// ConnectionManager Implementation
+// =============================================================================
+
+class ConnectionManager::Impl {
+public:
+    explicit Impl(const ConnectionManagerConfig& config)
+        : config_(config) {
+        if (config_.maxConnections == 0) {
+            throw std::invalid_argument("maxConnections must be greater than 0");
+        }
+    }
+
+    ~Impl() {
+        removeAllConnections();
+    }
+
+    std::string createConnection(const std::string& serverUrl, const std::string& name) {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        if (connections_.size() >= config_.maxConnections) {
+            throw std::runtime_error("Maximum number of connections reached");
+        }
+
+        std::string connectionId = generateConnectionId();
+
+        ConnectionInfo info;
+        info.id = connectionId;
+        info.name = name;
+        info.serverUrl = serverUrl;
+        info.state = ConnectionState::New;
+        info.createdAt = getCurrentTimeMs();
+
+        connections_[connectionId] = info;
+
+        return connectionId;
+    }
+
+    bool removeConnection(const std::string& connectionId) {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        auto it = connections_.find(connectionId);
+        if (it == connections_.end()) {
+            return false;
+        }
+
+        connections_.erase(it);
+        return true;
+    }
+
+    void removeAllConnections() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        connections_.clear();
+    }
+
+    ConnectionInfo getConnectionInfo(const std::string& connectionId) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        auto it = connections_.find(connectionId);
+        if (it == connections_.end()) {
+            throw std::runtime_error("Connection not found: " + connectionId);
+        }
+
+        return it->second;
+    }
+
+    std::vector<ConnectionInfo> getAllConnections() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        std::vector<ConnectionInfo> result;
+        result.reserve(connections_.size());
+
+        for (const auto& pair : connections_) {
+            result.push_back(pair.second);
+        }
+
+        return result;
+    }
+
+    bool connectionExists(const std::string& connectionId) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return connections_.find(connectionId) != connections_.end();
+    }
+
+    size_t getConnectionCount() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return connections_.size();
+    }
+
+    size_t getMaxConnections() const {
+        return config_.maxConnections;
+    }
+
+    bool hasAvailableSlots() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return connections_.size() < config_.maxConnections;
+    }
+
+    void updateConnectionState(const std::string& connectionId, ConnectionState state) {
+        ConnectionStateCallback callback;
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+
+            auto it = connections_.find(connectionId);
+            if (it == connections_.end()) {
+                throw std::runtime_error("Connection not found: " + connectionId);
+            }
+
+            it->second.state = state;
+            callback = stateCallback_;
+        }
+
+        if (callback) {
+            callback(connectionId, state);
+        }
+    }
+
+    void reportError(const std::string& connectionId, const std::string& error) {
+        ConnectionErrorCallback callback;
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            callback = errorCallback_;
+        }
+
+        if (callback) {
+            callback(connectionId, error);
+        }
+    }
+
+    void setStateCallback(ConnectionStateCallback callback) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stateCallback_ = std::move(callback);
+    }
+
+    void setErrorCallback(ConnectionErrorCallback callback) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        errorCallback_ = std::move(callback);
+    }
+
+private:
+    std::string generateConnectionId() {
+        // Generate a unique ID using random bytes
+        static std::random_device rd;
+        static std::mt19937 gen(rd());
+        static std::uniform_int_distribution<> dis(0, 15);
+        static const char* hex = "0123456789abcdef";
+
+        std::stringstream ss;
+        ss << "conn-";
+
+        for (int i = 0; i < 16; i++) {
+            ss << hex[dis(gen)];
+        }
+
+        return ss.str();
+    }
+
+    uint64_t getCurrentTimeMs() {
+        return static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch()
+            ).count()
+        );
+    }
+
+    ConnectionManagerConfig config_;
+    std::map<std::string, ConnectionInfo> connections_;
+    mutable std::mutex mutex_;
+    ConnectionStateCallback stateCallback_;
+    ConnectionErrorCallback errorCallback_;
+};
+
+// =============================================================================
+// ConnectionManager Public Interface
+// =============================================================================
+
+ConnectionManager::ConnectionManager(const ConnectionManagerConfig& config)
+    : impl_(std::make_unique<Impl>(config)) {}
+
+ConnectionManager::~ConnectionManager() = default;
+
+std::string ConnectionManager::createConnection(const std::string& serverUrl, const std::string& name) {
+    return impl_->createConnection(serverUrl, name);
+}
+
+bool ConnectionManager::removeConnection(const std::string& connectionId) {
+    return impl_->removeConnection(connectionId);
+}
+
+void ConnectionManager::removeAllConnections() {
+    impl_->removeAllConnections();
+}
+
+ConnectionInfo ConnectionManager::getConnectionInfo(const std::string& connectionId) const {
+    return impl_->getConnectionInfo(connectionId);
+}
+
+std::vector<ConnectionInfo> ConnectionManager::getAllConnections() const {
+    return impl_->getAllConnections();
+}
+
+bool ConnectionManager::connectionExists(const std::string& connectionId) const {
+    return impl_->connectionExists(connectionId);
+}
+
+size_t ConnectionManager::getConnectionCount() const {
+    return impl_->getConnectionCount();
+}
+
+size_t ConnectionManager::getMaxConnections() const {
+    return impl_->getMaxConnections();
+}
+
+bool ConnectionManager::hasAvailableSlots() const {
+    return impl_->hasAvailableSlots();
+}
+
+void ConnectionManager::updateConnectionState(const std::string& connectionId, ConnectionState state) {
+    impl_->updateConnectionState(connectionId, state);
+}
+
+void ConnectionManager::reportError(const std::string& connectionId, const std::string& error) {
+    impl_->reportError(connectionId, error);
+}
+
+void ConnectionManager::setStateCallback(ConnectionStateCallback callback) {
+    impl_->setStateCallback(std::move(callback));
+}
+
+void ConnectionManager::setErrorCallback(ConnectionErrorCallback callback) {
+    impl_->setErrorCallback(std::move(callback));
+}
+
+}  // namespace core
+}  // namespace obswebrtc

--- a/src/core/connection-manager.hpp
+++ b/src/core/connection-manager.hpp
@@ -1,0 +1,197 @@
+/**
+ * @file connection-manager.hpp
+ * @brief Multi-connection management for WebRTC streams
+ *
+ * This module provides:
+ * - Management of multiple concurrent WebRTC connections
+ * - Connection lifecycle management
+ * - Resource allocation and limits
+ * - Thread-safe operations
+ */
+
+#pragma once
+
+#include "peer-connection.hpp"
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace obswebrtc {
+namespace core {
+
+/**
+ * @brief Information about a managed connection
+ */
+struct ConnectionInfo {
+    std::string id;           ///< Unique connection identifier
+    std::string name;         ///< Human-readable name
+    std::string serverUrl;    ///< Server URL for the connection
+    ConnectionState state = ConnectionState::New;  ///< Current connection state
+    uint64_t createdAt = 0;   ///< Creation timestamp (ms since epoch)
+};
+
+/**
+ * @brief Callback for connection state changes
+ */
+using ConnectionStateCallback = std::function<void(const std::string& connectionId, ConnectionState state)>;
+
+/**
+ * @brief Callback for connection errors
+ */
+using ConnectionErrorCallback = std::function<void(const std::string& connectionId, const std::string& error)>;
+
+/**
+ * @brief Configuration for ConnectionManager
+ */
+struct ConnectionManagerConfig {
+    size_t maxConnections = 4;  ///< Maximum number of concurrent connections
+};
+
+/**
+ * @brief Manages multiple concurrent WebRTC connections
+ *
+ * This class provides centralized management for multiple WebRTC connections,
+ * including:
+ * - Connection creation and removal
+ * - Connection state tracking
+ * - Resource limits (max connections)
+ * - Thread-safe operations
+ *
+ * Example usage:
+ * @code
+ * ConnectionManagerConfig config;
+ * config.maxConnections = 4;
+ *
+ * ConnectionManager manager(config);
+ *
+ * // Create connections
+ * std::string conn1 = manager.createConnection("http://server/whep1", "Camera 1");
+ * std::string conn2 = manager.createConnection("http://server/whep2", "Camera 2");
+ *
+ * // Set callbacks
+ * manager.setStateCallback([](const std::string& id, ConnectionState state) {
+ *     std::cout << "Connection " << id << " state: " << static_cast<int>(state) << std::endl;
+ * });
+ *
+ * // Get connection info
+ * ConnectionInfo info = manager.getConnectionInfo(conn1);
+ *
+ * // Remove connection
+ * manager.removeConnection(conn1);
+ * @endcode
+ */
+class ConnectionManager {
+public:
+    /**
+     * @brief Construct a new Connection Manager
+     * @param config Configuration for the manager
+     * @throws std::invalid_argument if maxConnections is 0
+     */
+    explicit ConnectionManager(const ConnectionManagerConfig& config);
+
+    /**
+     * @brief Destructor - cleans up all connections
+     */
+    ~ConnectionManager();
+
+    // Delete copy constructor and assignment (non-copyable)
+    ConnectionManager(const ConnectionManager&) = delete;
+    ConnectionManager& operator=(const ConnectionManager&) = delete;
+
+    /**
+     * @brief Create a new connection
+     * @param serverUrl URL for the WebRTC server
+     * @param name Human-readable name for the connection
+     * @return Unique connection ID
+     * @throws std::runtime_error if max connections exceeded
+     */
+    std::string createConnection(const std::string& serverUrl, const std::string& name);
+
+    /**
+     * @brief Remove a connection
+     * @param connectionId ID of the connection to remove
+     * @return true if connection was removed, false if not found
+     */
+    bool removeConnection(const std::string& connectionId);
+
+    /**
+     * @brief Remove all connections
+     */
+    void removeAllConnections();
+
+    /**
+     * @brief Get connection information
+     * @param connectionId ID of the connection
+     * @return Connection information
+     * @throws std::runtime_error if connection not found
+     */
+    ConnectionInfo getConnectionInfo(const std::string& connectionId) const;
+
+    /**
+     * @brief Get all connections
+     * @return Vector of connection information
+     */
+    std::vector<ConnectionInfo> getAllConnections() const;
+
+    /**
+     * @brief Check if a connection exists
+     * @param connectionId ID of the connection
+     * @return true if connection exists
+     */
+    bool connectionExists(const std::string& connectionId) const;
+
+    /**
+     * @brief Get the current number of connections
+     * @return Number of active connections
+     */
+    size_t getConnectionCount() const;
+
+    /**
+     * @brief Get the maximum number of connections
+     * @return Maximum connection limit
+     */
+    size_t getMaxConnections() const;
+
+    /**
+     * @brief Check if there are available connection slots
+     * @return true if new connections can be created
+     */
+    bool hasAvailableSlots() const;
+
+    /**
+     * @brief Update connection state
+     * @param connectionId ID of the connection
+     * @param state New connection state
+     * @throws std::runtime_error if connection not found
+     */
+    void updateConnectionState(const std::string& connectionId, ConnectionState state);
+
+    /**
+     * @brief Report an error for a connection
+     * @param connectionId ID of the connection
+     * @param error Error message
+     */
+    void reportError(const std::string& connectionId, const std::string& error);
+
+    /**
+     * @brief Set callback for connection state changes
+     * @param callback Function to call on state changes
+     */
+    void setStateCallback(ConnectionStateCallback callback);
+
+    /**
+     * @brief Set callback for connection errors
+     * @param callback Function to call on errors
+     */
+    void setErrorCallback(ConnectionErrorCallback callback);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace core
+}  // namespace obswebrtc

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -300,6 +300,29 @@ else()
     gtest_discover_tests(hardware_encoder_test)
 endif()
 
+# Connection Manager test executable
+add_executable(connection_manager_test
+    connection_manager_test.cpp
+)
+
+target_include_directories(connection_manager_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+)
+
+target_link_libraries(connection_manager_test PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+    obs-webrtc-core
+)
+
+# Discover Connection Manager tests
+if(WIN32)
+    gtest_add_tests(TARGET connection_manager_test)
+else()
+    gtest_discover_tests(connection_manager_test)
+endif()
+
 # Settings Dialog test executable (requires Qt)
 if(QT_FOUND)
     add_executable(settings_dialog_test

--- a/tests/unit/connection_manager_test.cpp
+++ b/tests/unit/connection_manager_test.cpp
@@ -1,0 +1,449 @@
+/**
+ * @file connection_manager_test.cpp
+ * @brief Unit tests for ConnectionManager (multi-stream support)
+ */
+
+#include "core/connection-manager.hpp"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <thread>
+
+using namespace obswebrtc::core;
+using namespace testing;
+
+/**
+ * @brief Test fixture for ConnectionManager tests
+ */
+class ConnectionManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        config_.maxConnections = 4;
+    }
+
+    void TearDown() override {
+        // No teardown needed
+    }
+
+    ConnectionManagerConfig config_;
+};
+
+// =============================================================================
+// ConnectionInfo Tests
+// =============================================================================
+
+/**
+ * @brief Test default ConnectionInfo values
+ */
+TEST_F(ConnectionManagerTest, ConnectionInfoDefaultValues) {
+    ConnectionInfo info;
+
+    EXPECT_TRUE(info.id.empty());
+    EXPECT_TRUE(info.name.empty());
+    EXPECT_EQ(info.state, ConnectionState::New);
+    EXPECT_TRUE(info.serverUrl.empty());
+}
+
+// =============================================================================
+// ConnectionManager Construction Tests
+// =============================================================================
+
+/**
+ * @brief Test manager construction with default config
+ */
+TEST_F(ConnectionManagerTest, ConstructionWithDefaultConfig) {
+    ConnectionManagerConfig defaultConfig;
+    EXPECT_NO_THROW({
+        ConnectionManager manager(defaultConfig);
+    });
+}
+
+/**
+ * @brief Test manager construction with custom config
+ */
+TEST_F(ConnectionManagerTest, ConstructionWithCustomConfig) {
+    config_.maxConnections = 8;
+
+    EXPECT_NO_THROW({
+        ConnectionManager manager(config_);
+    });
+}
+
+/**
+ * @brief Test invalid max connections (zero)
+ */
+TEST_F(ConnectionManagerTest, InvalidMaxConnectionsZero) {
+    config_.maxConnections = 0;
+
+    EXPECT_THROW({
+        ConnectionManager manager(config_);
+    }, std::invalid_argument);
+}
+
+// =============================================================================
+// Connection Management Tests
+// =============================================================================
+
+/**
+ * @brief Test creating a connection
+ */
+TEST_F(ConnectionManagerTest, CreateConnection) {
+    ConnectionManager manager(config_);
+
+    std::string connId = manager.createConnection("http://localhost:8080/whep", "Test Connection");
+
+    EXPECT_FALSE(connId.empty());
+    EXPECT_EQ(manager.getConnectionCount(), 1);
+}
+
+/**
+ * @brief Test creating multiple connections
+ */
+TEST_F(ConnectionManagerTest, CreateMultipleConnections) {
+    ConnectionManager manager(config_);
+
+    std::string conn1 = manager.createConnection("http://localhost:8080/whep1", "Connection 1");
+    std::string conn2 = manager.createConnection("http://localhost:8080/whep2", "Connection 2");
+    std::string conn3 = manager.createConnection("http://localhost:8080/whep3", "Connection 3");
+
+    EXPECT_EQ(manager.getConnectionCount(), 3);
+    EXPECT_NE(conn1, conn2);
+    EXPECT_NE(conn2, conn3);
+    EXPECT_NE(conn1, conn3);
+}
+
+/**
+ * @brief Test exceeding max connections
+ */
+TEST_F(ConnectionManagerTest, ExceedMaxConnections) {
+    config_.maxConnections = 2;
+    ConnectionManager manager(config_);
+
+    manager.createConnection("http://localhost:8080/whep1", "Connection 1");
+    manager.createConnection("http://localhost:8080/whep2", "Connection 2");
+
+    EXPECT_THROW({
+        manager.createConnection("http://localhost:8080/whep3", "Connection 3");
+    }, std::runtime_error);
+}
+
+/**
+ * @brief Test removing a connection
+ */
+TEST_F(ConnectionManagerTest, RemoveConnection) {
+    ConnectionManager manager(config_);
+
+    std::string connId = manager.createConnection("http://localhost:8080/whep", "Test Connection");
+    EXPECT_EQ(manager.getConnectionCount(), 1);
+
+    bool removed = manager.removeConnection(connId);
+    EXPECT_TRUE(removed);
+    EXPECT_EQ(manager.getConnectionCount(), 0);
+}
+
+/**
+ * @brief Test removing non-existent connection
+ */
+TEST_F(ConnectionManagerTest, RemoveNonExistentConnection) {
+    ConnectionManager manager(config_);
+
+    bool removed = manager.removeConnection("non-existent-id");
+    EXPECT_FALSE(removed);
+}
+
+/**
+ * @brief Test getting connection info
+ */
+TEST_F(ConnectionManagerTest, GetConnectionInfo) {
+    ConnectionManager manager(config_);
+
+    std::string connId = manager.createConnection("http://localhost:8080/whep", "Test Connection");
+
+    ConnectionInfo info = manager.getConnectionInfo(connId);
+    EXPECT_EQ(info.id, connId);
+    EXPECT_EQ(info.name, "Test Connection");
+    EXPECT_EQ(info.serverUrl, "http://localhost:8080/whep");
+}
+
+/**
+ * @brief Test getting info for non-existent connection
+ */
+TEST_F(ConnectionManagerTest, GetNonExistentConnectionInfo) {
+    ConnectionManager manager(config_);
+
+    EXPECT_THROW({
+        manager.getConnectionInfo("non-existent-id");
+    }, std::runtime_error);
+}
+
+/**
+ * @brief Test getting all connections
+ */
+TEST_F(ConnectionManagerTest, GetAllConnections) {
+    ConnectionManager manager(config_);
+
+    manager.createConnection("http://localhost:8080/whep1", "Connection 1");
+    manager.createConnection("http://localhost:8080/whep2", "Connection 2");
+
+    std::vector<ConnectionInfo> connections = manager.getAllConnections();
+    EXPECT_EQ(connections.size(), 2);
+}
+
+/**
+ * @brief Test connection exists check
+ */
+TEST_F(ConnectionManagerTest, ConnectionExists) {
+    ConnectionManager manager(config_);
+
+    std::string connId = manager.createConnection("http://localhost:8080/whep", "Test Connection");
+
+    EXPECT_TRUE(manager.connectionExists(connId));
+    EXPECT_FALSE(manager.connectionExists("non-existent-id"));
+}
+
+// =============================================================================
+// Connection State Tests
+// =============================================================================
+
+/**
+ * @brief Test initial connection state
+ */
+TEST_F(ConnectionManagerTest, InitialConnectionState) {
+    ConnectionManager manager(config_);
+
+    std::string connId = manager.createConnection("http://localhost:8080/whep", "Test Connection");
+
+    ConnectionInfo info = manager.getConnectionInfo(connId);
+    EXPECT_EQ(info.state, ConnectionState::New);
+}
+
+/**
+ * @brief Test updating connection state
+ */
+TEST_F(ConnectionManagerTest, UpdateConnectionState) {
+    ConnectionManager manager(config_);
+
+    std::string connId = manager.createConnection("http://localhost:8080/whep", "Test Connection");
+
+    manager.updateConnectionState(connId, ConnectionState::Checking);
+    ConnectionInfo info = manager.getConnectionInfo(connId);
+    EXPECT_EQ(info.state, ConnectionState::Checking);
+
+    manager.updateConnectionState(connId, ConnectionState::Connected);
+    info = manager.getConnectionInfo(connId);
+    EXPECT_EQ(info.state, ConnectionState::Connected);
+}
+
+/**
+ * @brief Test updating state for non-existent connection
+ */
+TEST_F(ConnectionManagerTest, UpdateNonExistentConnectionState) {
+    ConnectionManager manager(config_);
+
+    EXPECT_THROW({
+        manager.updateConnectionState("non-existent-id", ConnectionState::Connected);
+    }, std::runtime_error);
+}
+
+// =============================================================================
+// Resource Management Tests
+// =============================================================================
+
+/**
+ * @brief Test removing all connections
+ */
+TEST_F(ConnectionManagerTest, RemoveAllConnections) {
+    ConnectionManager manager(config_);
+
+    manager.createConnection("http://localhost:8080/whep1", "Connection 1");
+    manager.createConnection("http://localhost:8080/whep2", "Connection 2");
+    manager.createConnection("http://localhost:8080/whep3", "Connection 3");
+
+    EXPECT_EQ(manager.getConnectionCount(), 3);
+
+    manager.removeAllConnections();
+
+    EXPECT_EQ(manager.getConnectionCount(), 0);
+}
+
+/**
+ * @brief Test has available slots
+ */
+TEST_F(ConnectionManagerTest, HasAvailableSlots) {
+    config_.maxConnections = 2;
+    ConnectionManager manager(config_);
+
+    EXPECT_TRUE(manager.hasAvailableSlots());
+
+    manager.createConnection("http://localhost:8080/whep1", "Connection 1");
+    EXPECT_TRUE(manager.hasAvailableSlots());
+
+    manager.createConnection("http://localhost:8080/whep2", "Connection 2");
+    EXPECT_FALSE(manager.hasAvailableSlots());
+}
+
+/**
+ * @brief Test get max connections
+ */
+TEST_F(ConnectionManagerTest, GetMaxConnections) {
+    config_.maxConnections = 8;
+    ConnectionManager manager(config_);
+
+    EXPECT_EQ(manager.getMaxConnections(), 8);
+}
+
+// =============================================================================
+// Connection Callback Tests
+// =============================================================================
+
+/**
+ * @brief Test connection state callback
+ */
+TEST_F(ConnectionManagerTest, ConnectionStateCallback) {
+    ConnectionManager manager(config_);
+    bool callbackInvoked = false;
+    std::string receivedConnId;
+    ConnectionState receivedState;
+
+    manager.setStateCallback([&](const std::string& connId, ConnectionState state) {
+        callbackInvoked = true;
+        receivedConnId = connId;
+        receivedState = state;
+    });
+
+    std::string connId = manager.createConnection("http://localhost:8080/whep", "Test Connection");
+    manager.updateConnectionState(connId, ConnectionState::Connected);
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_EQ(receivedConnId, connId);
+    EXPECT_EQ(receivedState, ConnectionState::Connected);
+}
+
+/**
+ * @brief Test error callback
+ */
+TEST_F(ConnectionManagerTest, ErrorCallback) {
+    ConnectionManager manager(config_);
+    bool callbackInvoked = false;
+    std::string receivedConnId;
+    std::string receivedError;
+
+    manager.setErrorCallback([&](const std::string& connId, const std::string& error) {
+        callbackInvoked = true;
+        receivedConnId = connId;
+        receivedError = error;
+    });
+
+    std::string connId = manager.createConnection("http://localhost:8080/whep", "Test Connection");
+    manager.reportError(connId, "Test error message");
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_EQ(receivedConnId, connId);
+    EXPECT_EQ(receivedError, "Test error message");
+}
+
+// =============================================================================
+// Thread Safety Tests
+// =============================================================================
+
+/**
+ * @brief Test concurrent connection creation
+ */
+TEST_F(ConnectionManagerTest, ConcurrentConnectionCreation) {
+    config_.maxConnections = 100;
+    ConnectionManager manager(config_);
+    const int numThreads = 10;
+    const int connectionsPerThread = 5;
+
+    std::vector<std::thread> threads;
+    std::atomic<int> successCount{0};
+
+    for (int i = 0; i < numThreads; i++) {
+        threads.emplace_back([&, i]() {
+            for (int j = 0; j < connectionsPerThread; j++) {
+                try {
+                    std::string url = "http://localhost:8080/whep" + std::to_string(i * connectionsPerThread + j);
+                    std::string name = "Connection " + std::to_string(i * connectionsPerThread + j);
+                    manager.createConnection(url, name);
+                    successCount++;
+                } catch (...) {
+                    // Ignore errors (max connections reached)
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(manager.getConnectionCount(), successCount.load());
+    EXPECT_LE(manager.getConnectionCount(), static_cast<size_t>(numThreads * connectionsPerThread));
+}
+
+/**
+ * @brief Test concurrent read/write operations
+ */
+TEST_F(ConnectionManagerTest, ConcurrentReadWrite) {
+    config_.maxConnections = 10;
+    ConnectionManager manager(config_);
+
+    // Create initial connections
+    std::string connId = manager.createConnection("http://localhost:8080/whep", "Test Connection");
+
+    std::atomic<bool> running{true};
+    const int iterations = 100;
+
+    // Writer thread
+    std::thread writer([&]() {
+        for (int i = 0; i < iterations && running; i++) {
+            manager.updateConnectionState(connId, ConnectionState::Checking);
+            manager.updateConnectionState(connId, ConnectionState::Connected);
+        }
+    });
+
+    // Reader thread
+    std::thread reader([&]() {
+        for (int i = 0; i < iterations && running; i++) {
+            try {
+                ConnectionInfo info = manager.getConnectionInfo(connId);
+                (void)info.state;  // Just access it
+            } catch (...) {
+                // Ignore if connection was removed
+            }
+        }
+    });
+
+    writer.join();
+    running = false;
+    reader.join();
+
+    // Should complete without crash
+    EXPECT_TRUE(manager.connectionExists(connId));
+}
+
+// =============================================================================
+// ID Generation Tests
+// =============================================================================
+
+/**
+ * @brief Test connection ID uniqueness
+ */
+TEST_F(ConnectionManagerTest, UniqueConnectionIds) {
+    config_.maxConnections = 100;
+    ConnectionManager manager(config_);
+
+    std::set<std::string> ids;
+    for (int i = 0; i < 50; i++) {
+        std::string connId = manager.createConnection(
+            "http://localhost:8080/whep" + std::to_string(i),
+            "Connection " + std::to_string(i)
+        );
+        EXPECT_TRUE(ids.find(connId) == ids.end()) << "Duplicate ID: " << connId;
+        ids.insert(connId);
+    }
+
+    EXPECT_EQ(ids.size(), 50);
+}


### PR DESCRIPTION
# Pull Request

## Summary
複数WebRTCストリーム同時受信のためのConnectionManager機能を追加

## Type
- [x] Feature (新機能)
- [ ] Bug Fix (バグ修正)
- [ ] Refactoring (リファクタリング)
- [ ] Documentation (ドキュメント)
- [ ] Testing (テスト追加・修正)
- [ ] Setup/Config (セットアップ・設定)
- [ ] Chore (その他の変更)

## Changes
- `ConnectionInfo` 構造体を追加（接続メタデータ格納用）
- `ConnectionManager` クラスを実装（複数接続の一元管理）
- 設定可能な最大接続数制限をサポート
- 接続状態の追跡とコールバック機能を実装
- スレッドセーフな操作（同時アクセス対応）
- 24個の包括的なユニットテストを追加

### 主な機能
- **接続の作成/削除**: `createConnection()`, `removeConnection()`, `removeAllConnections()`
- **接続情報の取得**: `getConnectionInfo()`, `getAllConnections()`, `connectionExists()`
- **リソース管理**: `getConnectionCount()`, `getMaxConnections()`, `hasAvailableSlots()`
- **状態管理**: `updateConnectionState()`, `setStateCallback()`
- **エラー処理**: `reportError()`, `setErrorCallback()`

## Test Plan
- [x] Manual testing completed
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Tested on Windows
- [ ] Tested with OBS Studio

### Test Steps
1. `cmake -B build -DBUILD_TESTS_ONLY=ON` でビルド設定
2. `cmake --build build --config Release --target connection_manager_test` でテストビルド
3. `./build/tests/unit/Release/connection_manager_test.exe` でテスト実行

### Expected Behavior
- 全24テストがパス
- 複数接続の管理が正しく動作
- スレッドセーフな操作が保証される

### Actual Behavior
期待通りに動作

## Related Issues
Closes #29

## Screenshots/Demo
N/A

## Checklist
- [x] Code follows the project's coding standards
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Tests pass locally
- [x] Build succeeds locally

## Additional Notes
このPRは複数ストリーム同時受信の基盤となる接続管理機能を実装しています。
実際のWebRTC接続（PeerConnection）との統合は後続のPRで実装予定です。

## Breaking Changes
- None

## Dependencies
- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)